### PR TITLE
Fix passing of compiler args in codegen and unit-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # knotx-gradle-plugins
 Gradle plugins that help manage Knot.x modules builds.
+
+
+### Local development and testing
+
+In order to properly develop and test new version of this plugin, you will need a working project on which tests will be carried out.
+
+When you have it prepared, add the following snippet at the beginning of the target project's `settings.gradle.kts` file:
+
+```kotlin
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
+```
+
+After that, you can push the new version of `knotx-gradle-plugins` to your local Maven repository (via Gradle's `publishToMavenLocal` task),
+and verify that the added functionality works as expected.  

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@
 
 group=io.knotx
 artifactId=knotx-gradle-plugin
-version=0.1.0
+version=0.1.1

--- a/src/main/kotlin/io/knotx/codegen.gradle.kts
+++ b/src/main/kotlin/io/knotx/codegen.gradle.kts
@@ -32,10 +32,9 @@ dependencies {
 
 tasks.named<JavaCompile>("compileJava") {
     options.annotationProcessorGeneratedSourcesDirectory = file("src/main/generated")
-    options.compilerArgs = listOf(
+    options.compilerArgs.addAll(listOf(
             "-processor", "io.vertx.codegen.CodeGenProcessor",
-            "-Acodegen.output=${project.projectDir}/docs"
-    )
+            "-Acodegen.output=${project.projectDir}/docs"))
 }
 
 sourceSets.named("main") {

--- a/src/main/kotlin/io/knotx/java-library.gradle.kts
+++ b/src/main/kotlin/io/knotx/java-library.gradle.kts
@@ -21,11 +21,11 @@ plugins {
 
 tasks.register<Jar>("sourcesJar") {
     from(sourceSets.named("main").get().allJava)
-    classifier = "sources"
+    archiveClassifier.set("sources")
 }
 tasks.register<Jar>("javadocJar") {
     from(tasks.named<Javadoc>("javadoc"))
-    classifier = "javadoc"
+    archiveClassifier.set("javadoc")
 }
 tasks.named<Javadoc>("javadoc") {
     if (JavaVersion.current().isJava9Compatible) {

--- a/src/main/kotlin/io/knotx/unit-test.gradle.kts
+++ b/src/main/kotlin/io/knotx/unit-test.gradle.kts
@@ -23,9 +23,7 @@ plugins {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    with(options) {
-        compilerArgs = listOf("-parameters")
-    }
+    options.compilerArgs.add("-parameters")
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
- Switch to `addAll` instead of reassignment
- Fixed deprecation warning for `classifier`
- Added quick guide for testing the plugin locally
- Bumped version to `0.1.1` as this is essentially a bugfix

Fixes #3.