### PR TITLE
publish-all task depends on test task in all submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to `knotx-fragments` will be documented in this file.
+
+## 1.0.3
+List of changes that are finished but not yet released in any final version.
+- [PR-xx](https://github.com/Knotx/knotx-fragments/pull/xx) - Run tests in all submodules during CI validation.
+
+## 1.0.2
+- [PR-6](https://github.com/Knotx/knotx-gradle-plugins/pull/6) - Adds Knot.x Distribution plugin to enable easy custom project setup.
+
+## 1.0.1
+- [PR-](https://github.com/Knotx/knotx-gradle-plugins/pull/4) - Fix passing of compiler args in codegen and unit-test
+
+## 1.0.0
+Initial open source release.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,17 @@
+# Copyright (C) 2019 Knot.x Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 trigger:
   - master
 
@@ -31,5 +45,9 @@ steps:
     displayName: "Build Docker image"
   - script: |
       cd knotx-repos/knotx-starter-kit
-      ./gradlew build
-    displayName: "Build Starter Kit"
+      ./gradlew build-stack
+    displayName: "Build Starter Kit: ZIP"
+  - script: |
+      cd knotx-repos/knotx-starter-kit
+      ./gradlew build-docker
+    displayName: "Build Starter Kit: Docker"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@
 
 group=io.knotx
 artifactId=knotx-gradle-plugin
-version=0.1.2
+version=0.1.3

--- a/src/main/kotlin/io/knotx/publish-all-composite.gradle.kts
+++ b/src/main/kotlin/io/knotx/publish-all-composite.gradle.kts
@@ -31,4 +31,12 @@ subprojects {
             dependsOn("${this@subprojects.path}:publishToMavenLocal")
         }
     }
+    plugins.withType<JavaPlugin> {
+        publishTask {
+            dependsOn(dependsOn("${this@subprojects.path}:test"))
+        }
+        publishLocalTask {
+            dependsOn("${this@subprojects.path}:test")
+        }
+    }
 }


### PR DESCRIPTION
Run tests when publish-all-local is executed by CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.