### PR TITLE
Execute tests from all included knotx-stack builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-XX](https://github.com/Knotx/knotx-gradle-plugins/pull/XX) Add support for running tests for each composite-build modules tests (see  [Knotx/knotx-stack#57](https://github.com/Knotx/knotx-stack/issues/57)) and renamed `publish-all-composite` to `composite-build-support`
                 
 ## 2.2.0
 - [PR-10](https://github.com/Knotx/knotx-gradle-plugins/pull/10) Knot.x release gradle plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
-- [PR-XX](https://github.com/Knotx/knotx-gradle-plugins/pull/XX) Add support for running tests for each composite-build modules tests (see  [Knotx/knotx-stack#57](https://github.com/Knotx/knotx-stack/issues/57)) and renamed `publish-all-composite` to `composite-build-support`
+- [PR-35](https://github.com/Knotx/knotx-gradle-plugins/pull/35) Add support for running tests for each composite-build modules tests (see  [Knotx/knotx-stack#57](https://github.com/Knotx/knotx-stack/issues/57)) and renamed `publish-all-composite` to `composite-build-support`
                 
 ## 2.2.0
 - [PR-10](https://github.com/Knotx/knotx-gradle-plugins/pull/10) Knot.x release gradle plugins

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,9 +172,9 @@ fun setNameAndDescription(node: groovy.util.Node, publicationName: String) {
             node.appendNode("name", "Knot.x Gradle Maven Publish Plugin")
             node.appendNode("description", "Defaults for maven-publish plugin in Knot.x modules.")
         }
-        "io.knotx.publish-all-compositePluginMarkerMaven" -> {
+        "io.knotx.composite-build-supportPluginMarkerMaven" -> {
             node.appendNode("name", "Knot.x Gradle Composite Plugin")
-            node.appendNode("description", "Publish all support for Knot.x Aggregator.")
+            node.appendNode("description", "Composite build modules support for Knot.x Stack.")
         }
         "io.knotx.unit-testPluginMarkerMaven" -> {
             node.appendNode("name", "Knot.x Gradle Unit Test Plugin")

--- a/src/main/kotlin/io/knotx/composite-build-support.gradle.kts
+++ b/src/main/kotlin/io/knotx/composite-build-support.gradle.kts
@@ -18,6 +18,8 @@ package io.knotx
 val publishLocalTask: TaskProvider<Task> = tasks.register("publishToMavenLocal") {
     group = "composite-build"
 }
+// to keep the root project context in subprojects section
+val theProject = project
 
 subprojects {
     plugins.withId("maven-publish") {
@@ -27,6 +29,11 @@ subprojects {
     }
     plugins.withType<JavaPlugin> {
         publishLocalTask {
+            dependsOn("${this@subprojects.path}:test")
+        }
+    }
+    plugins.withType<JavaPlugin> {
+        theProject.tasks.named("check") {
             dependsOn("${this@subprojects.path}:test")
         }
     }


### PR DESCRIPTION
## Description
Add support for running tests for each composite-build modules tests. Apply plugin `composite-build-support` (renamed `publish-all-composite`).

## Motivation and Context
https://github.com/Knotx/knotx-stack/issues/57

## Upgrade notes
Anywhere in the project, where you have applied `publish-all-composite` plugin, please change from:
```gradle
plugins {
  // ...
  id("io.knotx.publish-all-composite")
}
```
to
```gradle
plugins {
  // ...
  id("io.knotx.composite-build-support")
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.