### PR TITLE
Disable -html5 javadoc flag - not available for JDK 8.

### DIFF
--- a/src/main/kotlin/io/knotx/java-library.gradle.kts
+++ b/src/main/kotlin/io/knotx/java-library.gradle.kts
@@ -29,9 +29,10 @@ tasks.register<Jar>("javadocJar") {
     archiveClassifier.set("javadoc")
 }
 tasks.named<Javadoc>("javadoc") {
-    if (JavaVersion.current().isJava9Compatible) {
-        (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
-    }
+    // we force JDK 8: https://docs.gradle.org/6.7/release-notes.html
+    //    if (JavaVersion.current().isJava9Compatible) {
+    //        (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
+    //    }
 }
 
 tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
Disable `-html5` javadoc flag - not available in JDK 8.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
